### PR TITLE
Update to GeckoView Nightly 113.0.20230406092115 on main

### DIFF
--- a/android-components/plugins/dependencies/src/main/java/Gecko.kt
+++ b/android-components/plugins/dependencies/src/main/java/Gecko.kt
@@ -9,7 +9,7 @@ object Gecko {
     /**
      * GeckoView Version.
      */
-    const val version = "113.0.20230404093915"
+    const val version = "113.0.20230406092115"
 
     /**
      * GeckoView channel


### PR DESCRIPTION
This (automated) patch updates GV Nightly on main to 113.0.20230406092115.