### PR TITLE
Update to GeckoView Nightly 114.0.20230418091934 on main

### DIFF
--- a/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt
+++ b/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt
@@ -45,7 +45,7 @@ object Versions {
     const val mozilla_appservices = "97.4.0"
 
     // DO NOT MODIFY MANUALLY. This is auto-updated along with GeckoView.
-    const val mozilla_glean = "52.4.2"
+    const val mozilla_glean = "52.5.0"
 
     const val material = "1.2.1"
     const val ksp = "1.0.9"

--- a/android-components/plugins/dependencies/src/main/java/Gecko.kt
+++ b/android-components/plugins/dependencies/src/main/java/Gecko.kt
@@ -9,7 +9,7 @@ object Gecko {
     /**
      * GeckoView Version.
      */
-    const val version = "113.0.20230404093915"
+    const val version = "114.0.20230418091934"
 
     /**
      * GeckoView channel


### PR DESCRIPTION
This (automated) patch updates GV Nightly on main to 114.0.20230418091934.